### PR TITLE
fix(tokenname): make controlplaneauth token uniq

### DIFF
--- a/internal/controller/controlplaneauth/controller.go
+++ b/internal/controller/controlplaneauth/controller.go
@@ -163,7 +163,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	t, err := c.tokens.Create(ctx, &tokens.TokenCreateParameters{
 		Attributes: tokens.TokenAttributes{
-			Name: cr.Spec.ForProvider.ControlPlaneName,
+			Name: fmt.Sprintf("%.64s", cr.Spec.ForProvider.ControlPlaneName+"-"+string(cr.UID)),
 		},
 		Relationships: tokens.TokenRelationships{
 			Owner: tokens.TokenOwner{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The problem is that the `up cli` https://github.com/upbound/up/blob/1ccd310/cmd/up/controlplane/connect.go#L171
 uses the controlplane name to create a token name, which can result in conflicts like the one shown here: `cannot create token: Conflict: {"errors":[{"detail":"a token with this name already exists for this owner"}]}`. To resolve this issue, we should ensure that the token names are unique so add cr.UID 


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```
kubectl describe -f controlplaneauth.yaml 
Name:         haarchri-display-nothing
Namespace:    
Labels:       <none>
Annotations:  crossplane.io/external-create-pending: 2023-09-21T21:37:53+02:00
              crossplane.io/external-create-succeeded: 2023-09-21T21:37:54+02:00
              crossplane.io/external-name: 64187e53-7b3f-4763-a08d-073456d99e18
API Version:  mcp.upbound.io/v1alpha1
Kind:         ControlPlaneAuth
Metadata:
  Creation Timestamp:  2023-09-21T19:37:53Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:        1
  Resource Version:  270799
  UID:               5fdc5b4a-6b2a-454f-ba6b-b831a4f5145e
Spec:
  Deletion Policy:  Delete
  For Provider:
    Control Plane Name:  haarchri-display-nothing
    Organization Name:   upbound
  Provider Config Ref:
    Name:  default
  Write Connection Secret To Ref:
    Name:       controlplane-a-kubeconfig
    Namespace:  upbound-system
Status:
  At Provider:
  Conditions:
    Last Transition Time:  2023-09-21T19:37:54Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2023-09-21T19:37:54Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
Events:
  Type    Reason                   Age   From                                     Message
  ----    ------                   ----  ----                                     -------
  Normal  CreatedExternalResource  20s   managed/controlplaneauth.mcp.upbound.io  Successfully requested creation of external resource
```

![image](https://github.com/upbound/provider-upbound/assets/21083497/fba360bf-58f1-4731-a408-d13b2b89ba27)


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
