### PR TITLE
Fix version comparisions so that an increment from 9 to 10 does not result in a "downgrade"

### DIFF
--- a/internal/client/controlplane/client_test.go
+++ b/internal/client/controlplane/client_test.go
@@ -14,6 +14,7 @@ func TestCompareVersionsWithBuildMetadata(t *testing.T) {
 		{"v0.0.0+13.7104e10", "v0.0.0+13.7104e10", 0},
 		{"v0.0.0+14.6b092f3", "v0.0.0+13.7104e10", 1},
 		{"v0.0.0+13.7104e10", "v0.0.0+14.6b092f3", -1},
+		{"v0.0.0+10.7104e10", "v0.0.0+9.6b092f3", 1},
 	}
 
 	for _, tc := range testCases {

--- a/internal/controller/controlplane/controller.go
+++ b/internal/controller/controlplane/controller.go
@@ -178,7 +178,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		version := pointer.StringDeref(cr.Spec.ForProvider.Version, "")
 		currentVersion := pointer.StringDeref(resp.ControlPlane.Configuration.CurrentVersion, "")
 
-		if controlplane.CompareVersions(version, currentVersion) == 1 {
+		if controlplane.CompareVersions(version, currentVersion) != 0 {
 			return managed.ExternalObservation{
 				ResourceExists:   true,
 				ResourceUpToDate: false,


### PR DESCRIPTION
### Description of your changes
- update version check in observe to allow a supplied version to assert that that is the expected version (downgrade or upgrade)
- adjust CompareVersion logic so that we compare based on commit number rather than string compare on two incrementing commit numbers.


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
New unit tests

[contribution process]: https://git.io/fj2m9
