### PR TITLE
add visibility and publish fields to Repository resource

### DIFF
--- a/apis/repository/v1alpha1/repository_types.go
+++ b/apis/repository/v1alpha1/repository_types.go
@@ -36,6 +36,14 @@ type RepositoryParameters struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	OrganizationName string `json:"organizationName"`
+
+	// Public determines the visibility of the repository
+	// +kubebuilder:validation:Optional
+	Public bool `json:"public"`
+
+	// Publish enables Upbound Marketplace listing page for the new repository
+	// +kubebuilder:validation:Optional
+	Publish bool `json:"publish"`
 }
 
 // RepositoryObservation are the observable fields of a Repository.
@@ -45,6 +53,7 @@ type RepositoryObservation struct {
 	AccountID      uint                `json:"accountId"`
 	Type           *sdk.RepositoryType `json:"type,omitempty"`
 	Public         bool                `json:"public"`
+	Publish        *sdk.PublishPolicy  `json:"publishPolicy"`
 	Official       bool                `json:"official"`
 	CurrentVersion *string             `json:"currentVersion,omitempty"`
 	CreatedAt      metav1.Time         `json:"createdAt"`

--- a/apis/repository/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/repository/v1alpha1/zz_generated.deepcopy.go
@@ -246,6 +246,11 @@ func (in *RepositoryObservation) DeepCopyInto(out *RepositoryObservation) {
 		*out = new(repositories.RepositoryType)
 		**out = **in
 	}
+	if in.Publish != nil {
+		in, out := &in.Publish, &out.Publish
+		*out = new(repositories.PublishPolicy)
+		**out = **in
+	}
 	if in.CurrentVersion != nil {
 		in, out := &in.CurrentVersion, &out.CurrentVersion
 		*out = new(string)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20240522174801-1ad3d4c87f21
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
-	github.com/upbound/up-sdk-go v1.11.0
+	github.com/upbound/up-sdk-go v1.12.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.7
 require (
 	github.com/crossplane/crossplane-runtime v1.18.0
 	github.com/crossplane/crossplane-tools v0.0.0-20240522174801-1ad3d4c87f21
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/upbound/up-sdk-go v1.12.0
@@ -22,7 +23,6 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/upbound/up-sdk-go v1.11.0 h1:KuZ4dw9vQFp7j9TfpKeuReP/gDxhnBe2IkFec55E3fE=
-github.com/upbound/up-sdk-go v1.11.0/go.mod h1:LO1oxiu1bQwCLxeWpo33rgW4v3rIGx9QPyhYacRAPQE=
+github.com/upbound/up-sdk-go v1.12.0 h1:Kx9vL9Ec6oniY/2QO86SBwVxgeo0INsjhL4vhkpvLeA=
+github.com/upbound/up-sdk-go v1.12.0/go.mod h1:LO1oxiu1bQwCLxeWpo33rgW4v3rIGx9QPyhYacRAPQE=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=

--- a/internal/client/repository/client.go
+++ b/internal/client/repository/client.go
@@ -34,6 +34,7 @@ func StatusFromResponse(resp repositories.Repository) v1alpha1.RepositoryObserva
 	status.Name = resp.Name
 	status.Official = resp.Official
 	status.Public = resp.Public
+	status.Publish = resp.Publish
 	status.RepositoryID = resp.RepositoryID
 	status.Type = resp.Type
 	if resp.UpdatedAt != nil {

--- a/internal/controller/repository/client.go
+++ b/internal/controller/repository/client.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"context"
+
+	repos "github.com/upbound/up-sdk-go/service/repositories"
+)
+
+type RepoClient interface {
+	Get(ctx context.Context, org string, repo string) (*repos.RepositoryResponse, error)
+
+	CreateOrUpdateWithOptions(ctx context.Context, org string, repo string, opts ...repos.CreateOrUpdateOption) error
+
+	Delete(ctx context.Context, account, name string) error
+}

--- a/internal/controller/repository/controller.go
+++ b/internal/controller/repository/controller.go
@@ -110,7 +110,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &external{
-		repositories: repositories.NewClient(cfg),
+		repositories: &sdkClient{upstream: repos.NewClient(cfg)},
 	}, nil
 }
 
@@ -122,7 +122,7 @@ func (e *external) Disconnect(ctx context.Context) error {
 // An ExternalClient observes, then either creates, updates, or deletes an
 // external resource to ensure it reflects the managed resource's desired state.
 type external struct {
-	repositories *repositories.Client
+	repositories RepoClient
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {

--- a/internal/controller/repository/controller.go
+++ b/internal/controller/repository/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -146,9 +147,16 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr.Status.SetConditions(v1.Available())
 	cr.Status.AtProvider = repository.StatusFromResponse(repoList.Repositories[0])
 
+	publishPolicy := repositories.PublishPolicy("draft")
+	if cr.Spec.ForProvider.Publish {
+		publishPolicy = repositories.PublishPolicy("publish")
+	}
+
+	resourceUpToDate := cr.Spec.ForProvider.Public == resp.Public || ptr.Deref(resp.Publish, repositories.PublishPolicy("")) == publishPolicy
+
 	return managed.ExternalObservation{
 		ResourceExists:   true,
-		ResourceUpToDate: true,
+		ResourceUpToDate: resourceUpToDate,
 	}, nil
 }
 
@@ -157,8 +165,9 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotRepository)
 	}
-
-	err := c.repositories.CreateOrUpdateWithOptions(ctx, cr.Spec.ForProvider.OrganizationName, cr.Spec.ForProvider.Name)
+	visibility := createOrUpdatePublic(cr.Spec.ForProvider.Public)
+	publishPolicy := createOrUpdatePublish(cr.Spec.ForProvider.Publish)
+	err := c.repositories.CreateOrUpdateWithOptions(ctx, cr.Spec.ForProvider.OrganizationName, cr.Spec.ForProvider.Name, visibility, publishPolicy)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "cannot create repository")
 	}
@@ -166,8 +175,19 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalCreation{}, nil
 }
 
-func (c *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {
-	// There is no Update repositories in repository API.
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*v1alpha1.Repository)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotRepository)
+	}
+	visibility := createOrUpdatePublic(cr.Spec.ForProvider.Public)
+	publishPolicy := createOrUpdatePublish(cr.Spec.ForProvider.Publish)
+
+	err := c.repositories.CreateOrUpdateWithOptions(ctx, cr.Spec.ForProvider.OrganizationName, cr.Spec.ForProvider.Name, visibility, publishPolicy)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, "cannot update repository")
+	}
+
 	return managed.ExternalUpdate{}, nil
 }
 
@@ -178,4 +198,20 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	return managed.ExternalDelete{}, errors.Wrap(resource.Ignore(uperrors.IsNotFound, c.repositories.Delete(ctx, cr.Spec.ForProvider.OrganizationName, meta.GetExternalName(cr))), "cannot delete repository")
+}
+
+func createOrUpdatePublic(isPublic bool) repositories.CreateOrUpdateOption {
+	private := repositories.WithPublic()
+	if !isPublic {
+		private = repositories.WithPrivate()
+	}
+	return private
+}
+
+func createOrUpdatePublish(publish bool) repositories.CreateOrUpdateOption {
+	publishPolicy := repositories.WithDraft()
+	if publish {
+		publishPolicy = repositories.WithPublish()
+	}
+	return publishPolicy
 }

--- a/internal/controller/repository/controller_test.go
+++ b/internal/controller/repository/controller_test.go
@@ -1,0 +1,151 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	managed "github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/upbound/up-sdk-go/service/repositories"
+	repos "github.com/upbound/up-sdk-go/service/repositories"
+
+	"github.com/upbound/provider-upbound/apis/repository/v1alpha1"
+)
+
+func TestObserve(t *testing.T) {
+	type args struct {
+		mg resource.Managed
+	}
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		setupMocks func(m *mockClient)
+		args       args
+		want       want
+	}{
+		"ExternalNameEmpty": {
+			args: args{
+				mg: &v1alpha1.Repository{},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists: false,
+				},
+				err: nil,
+			},
+		},
+		"RepoNotFound": {
+			setupMocks: func(m *mockClient) {
+				m.getFn = func(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error) {
+					return nil, errors.New("not found")
+				}
+			},
+			args: args{
+				mg: &v1alpha1.Repository{
+					Spec: v1alpha1.RepositorySpec{
+						ForProvider: v1alpha1.RepositoryParameters{
+							OrganizationName: "org",
+						},
+					},
+				},
+			},
+			want: want{
+				o:   managed.ExternalObservation{},
+				err: nil,
+			},
+		},
+		"RepoUpToDate": {
+			setupMocks: func(m *mockClient) {
+				m.getFn = func(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error) {
+					return &repos.RepositoryResponse{
+						Repository: repos.Repository{
+							Public:  true,
+							Publish: ptr.To(repositories.PublishPolicy("publish")),
+						},
+					}, nil
+				}
+			},
+			args: args{
+				mg: &v1alpha1.Repository{
+					Spec: v1alpha1.RepositorySpec{
+						ForProvider: v1alpha1.RepositoryParameters{
+							OrganizationName: "org",
+							Public:           true,
+							Publish:          true,
+						},
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"crossplane.io/external-name": "name"},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		"RepoOutOfSync": {
+			setupMocks: func(m *mockClient) {
+				m.getFn = func(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error) {
+					return &repos.RepositoryResponse{
+						Repository: repos.Repository{
+							Public:  false,
+							Publish: ptr.To(repositories.PublishPolicy("draft")),
+						},
+					}, nil
+				}
+			},
+			args: args{
+				mg: &v1alpha1.Repository{
+					Spec: v1alpha1.RepositorySpec{
+						ForProvider: v1alpha1.RepositoryParameters{
+							OrganizationName: "org",
+							Public:           true,
+							Publish:          true,
+						},
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"crossplane.io/external-name": "name"},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mockClient := &mockClient{}
+			if tc.setupMocks != nil {
+				tc.setupMocks(mockClient)
+			}
+			e := &external{repositories: mockClient}
+
+			got, err := e.Observe(context.Background(), tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("unexpected observation (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/controller/repository/mock.go
+++ b/internal/controller/repository/mock.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+
+	repos "github.com/upbound/up-sdk-go/service/repositories"
+)
+
+type mockClient struct {
+	getFn            func(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error)
+	createOrUpdateFn func(ctx context.Context, org, repo string, opts ...repos.CreateOrUpdateOption) error
+	deleteFn         func(ctx context.Context, account, name string) error
+}
+
+func (m *mockClient) Get(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error) {
+	return m.getFn(ctx, org, repo)
+}
+
+func (m *mockClient) CreateOrUpdateWithOptions(ctx context.Context, org, repo string, opts ...repos.CreateOrUpdateOption) error {
+	return m.createOrUpdateFn(ctx, org, repo, opts...)
+}
+
+func (m *mockClient) Delete(ctx context.Context, account, name string) error { // nolint:interfacer
+	return m.deleteFn(ctx, account, name)
+}

--- a/internal/controller/repository/sdkClient.go
+++ b/internal/controller/repository/sdkClient.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"context"
+
+	repos "github.com/upbound/up-sdk-go/service/repositories"
+)
+
+type sdkClient struct {
+	upstream *repos.Client
+}
+
+func (s *sdkClient) Get(ctx context.Context, org, repo string) (*repos.RepositoryResponse, error) {
+	return s.upstream.Get(ctx, org, repo)
+}
+
+func (s *sdkClient) CreateOrUpdateWithOptions(ctx context.Context, org, repo string, opts ...repos.CreateOrUpdateOption) error {
+	return s.upstream.CreateOrUpdateWithOptions(ctx, org, repo, opts...)
+}
+
+func (s *sdkClient) Delete(ctx context.Context, account, name string) error { // nolint:interfacer
+	return s.upstream.Delete(ctx, account, name)
+}

--- a/package/crds/repository.upbound.io_repositories.yaml
+++ b/package/crds/repository.upbound.io_repositories.yaml
@@ -83,6 +83,13 @@ spec:
                       belongs.
                     minLength: 1
                     type: string
+                  public:
+                    description: Public determines the visibility of the repository
+                    type: boolean
+                  publish:
+                    description: Publish enables Upbound Marketplace listing page
+                      for the new repository
+                    type: boolean
                 required:
                 - name
                 - organizationName
@@ -274,6 +281,10 @@ spec:
                     type: boolean
                   public:
                     type: boolean
+                  publishPolicy:
+                    description: PublishingPolicy determines whether packages will
+                      be indexed
+                    type: string
                   repositoryId:
                     type: integer
                   type:
@@ -288,6 +299,7 @@ spec:
                 - name
                 - official
                 - public
+                - publishPolicy
                 - repositoryId
                 type: object
               conditions:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

tested locally with the following resource
```yaml
➭ cat provider-upbound-repo-test.yaml
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  annotations:
    crossplane.io/external-name: provider-upbound-repo-update
  name: provider-upbound-repo-update
spec:
  deletionPolicy: Delete
  forProvider:
    name: provider-upbound-repo-update
    organizationName: upbound
    public: true
    publish: false%
```
applied the changes to my local ctp (kind) and saw the following output
```yaml
➭ k get repository provider-upbound-repo-update  -o yaml
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  annotations:
    crossplane.io/external-name: provider-upbound-repo-update
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"repository.upbound.io/v1alpha1","kind":"Repository","metadata":{"annotations":{"crossplane.io/external-name":"provider-upbound-repo-update"},"name":"provider-upbound-repo-update"},"spec":{"deletionPolicy":"Delete","forProvider":{"name":"provider-upbound-repo-update","organizationName":"upbound","public":true,"publish":false}}}
  creationTimestamp: "2025-03-24T22:21:46Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 1
  name: provider-upbound-repo-update
  resourceVersion: "1590"
  uid: 7788e856-df72-4abc-8f4b-18194148f8c5
spec:
  deletionPolicy: Delete
  forProvider:
    name: provider-upbound-repo-update
    organizationName: upbound
    public: true
    publish: false
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    accountId: 4
    createdAt: "2025-03-24T14:21:23Z"
    name: provider-upbound-repo-update
    official: false
    public: true
    publishPolicy: draft
    repositoryId: 10319
    updatedAt: "2025-03-24T20:18:24Z"
  conditions:
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```
updated the yaml file then reapplied
```yaml
➭ cat provider-upbound-repo-test.yaml
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  annotations:
    crossplane.io/external-name: provider-upbound-repo-update
  name: provider-upbound-repo-update
spec:
  deletionPolicy: Delete
  forProvider:
    name: provider-upbound-repo-update
    organizationName: upbound
    public: false
    publish: true%
➭ k apply -f provider-upbound-repo-test.yaml
repository.repository.upbound.io/provider-upbound-repo-update configured
➭ k get repository provider-upbound-repo-update  -o yaml
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  annotations:
    crossplane.io/external-name: provider-upbound-repo-update
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"repository.upbound.io/v1alpha1","kind":"Repository","metadata":{"annotations":{"crossplane.io/external-name":"provider-upbound-repo-update"},"name":"provider-upbound-repo-update"},"spec":{"deletionPolicy":"Delete","forProvider":{"name":"provider-upbound-repo-update","organizationName":"upbound","public":false,"publish":true}}}
  creationTimestamp: "2025-03-24T22:21:46Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 2
  name: provider-upbound-repo-update
  resourceVersion: "1757"
  uid: 7788e856-df72-4abc-8f4b-18194148f8c5
spec:
  deletionPolicy: Delete
  forProvider:
    name: provider-upbound-repo-update
    organizationName: upbound
    public: false
    publish: true
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    accountId: 4
    createdAt: "2025-03-24T14:21:23Z"
    name: provider-upbound-repo-update
    official: false
    public: true
    publishPolicy: draft
    repositoryId: 10319
    updatedAt: "2025-03-24T20:18:24Z"
  conditions:
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```
looked at the events to see the update event
```
➭ kgetevents
LAST SEEN   TYPE     REASON                    OBJECT                                    MESSAGE
9m          Normal   Starting                  node/provider-upbound-dev-control-plane
9m16s       Normal   Starting                  node/provider-upbound-dev-control-plane   Starting kubelet.
9m16s       Normal   NodeAllocatableEnforced   node/provider-upbound-dev-control-plane   Updated Node Allocatable limit across pods
9m16s       Normal   NodeHasSufficientMemory   node/provider-upbound-dev-control-plane   Node provider-upbound-dev-control-plane status is now: NodeHasSufficientMemory
9m16s       Normal   NodeHasNoDiskPressure     node/provider-upbound-dev-control-plane   Node provider-upbound-dev-control-plane status is now: NodeHasNoDiskPressure
9m16s       Normal   NodeHasSufficientPID      node/provider-upbound-dev-control-plane   Node provider-upbound-dev-control-plane status is now: NodeHasSufficientPID
9m1s        Normal   RegisteredNode            node/provider-upbound-dev-control-plane   Node provider-upbound-dev-control-plane event: Registered Node provider-upbound-dev-control-plane in Controller
8m59s       Normal   NodeReady                 node/provider-upbound-dev-control-plane   Node provider-upbound-dev-control-plane status is now: NodeReady
49s         Normal   UpdatedExternalResource   repository/provider-upbound-repo-update   Successfully requested update of external resource
```
resource was updated about a minute after apply 
```
➭ k get repository provider-upbound-repo-update  -o yaml
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  annotations:
    crossplane.io/external-name: provider-upbound-repo-update
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"repository.upbound.io/v1alpha1","kind":"Repository","metadata":{"annotations":{"crossplane.io/external-name":"provider-upbound-repo-update"},"name":"provider-upbound-repo-update"},"spec":{"deletionPolicy":"Delete","forProvider":{"name":"provider-upbound-repo-update","organizationName":"upbound","public":false,"publish":true}}}
  creationTimestamp: "2025-03-24T22:21:46Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 2
  name: provider-upbound-repo-update
  resourceVersion: "1869"
  uid: 7788e856-df72-4abc-8f4b-18194148f8c5
spec:
  deletionPolicy: Delete
  forProvider:
    name: provider-upbound-repo-update
    organizationName: upbound
    public: false
    publish: true
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    accountId: 4
    createdAt: "2025-03-24T14:21:23Z"
    name: provider-upbound-repo-update
    official: false
    public: false
    publishPolicy: publish
    repositoryId: 10319
    updatedAt: "2025-03-24T22:23:04Z"
  conditions:
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-03-24T22:21:51Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```
controller output for update
```
#### TESTING UPDATE ###

2025-03-24T17:23:03-05:00       DEBUG   provider-upbound        Reconciling     {"controller": "managed/repository.repository.upbound.io", "request": {"name":"provider-upbound-repo-update"}}
2025-03-24T17:23:04-05:00       DEBUG   provider-upbound        Successfully requested update of external resource      {"controller": "managed/repository.repository.upbound.io", "request": {"name":"provider-upbound-repo-update"}, "uid": "7788e856-df72-4abc-8f4b-18194148f8c5", "version": "1757", "external-name": "provider-upbound-repo-update", "requeue-after": "2025-03-24T17:24:04-05:00"}
2025-03-24T17:23:04-05:00       DEBUG   events  Successfully requested update of external resource      {"type": "Normal", "object": {"kind":"Repository","name":"provider-upbound-repo-update","uid":"7788e856-df72-4abc-8f4b-18194148f8c5","apiVersion":"repository.upbound.io/v1alpha1","resourceVersion":"1757"}, "reason": "UpdatedExternalResource"}
2025-03-24T17:23:51-05:00       DEBUG   provider-upbound        Reconciling     {"controller": "managed/repository.repository.upbound.io", "request": {"name":"provider-upbound-repo-update"}}
2025-03-24T17:23:51-05:00       DEBUG   provider-upbound        External resource is up to date {"controller": "managed/repository.repository.upbound.io", "request": {"name":"provider-upbound-repo-update"}, "uid": "7788e856-df72-4abc-8f4b-18194148f8c5", "version": "1757", "external-name": "provider-upbound-repo-update", "requeue-after": "2025-03-24T17:24:51-05:00"}
```
