### PR TITLE
set defaults for public and publish values

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 2m
+  timeout: 3m
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
@@ -22,7 +22,7 @@ linters-settings:
 
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    shadow: false
 
   golint:
     # minimal confidence for issues, default is 0.8

--- a/apis/repository/v1alpha1/repository_types.go
+++ b/apis/repository/v1alpha1/repository_types.go
@@ -39,10 +39,12 @@ type RepositoryParameters struct {
 
 	// Public determines the visibility of the repository
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
 	Public bool `json:"public"`
 
 	// Publish enables Upbound Marketplace listing page for the new repository
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
 	Publish bool `json:"publish"`
 }
 

--- a/apis/repository/v1alpha1/repository_types.go
+++ b/apis/repository/v1alpha1/repository_types.go
@@ -38,12 +38,12 @@ type RepositoryParameters struct {
 	OrganizationName string `json:"organizationName"`
 
 	// Public determines the visibility of the repository
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +kubebuilder:default=false
 	Public bool `json:"public"`
 
 	// Publish enables Upbound Marketplace listing page for the new repository
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +kubebuilder:default=false
 	Publish bool `json:"publish"`
 }

--- a/package/crds/repository.upbound.io_repositories.yaml
+++ b/package/crds/repository.upbound.io_repositories.yaml
@@ -95,6 +95,8 @@ spec:
                 required:
                 - name
                 - organizationName
+                - public
+                - publish
                 type: object
               managementPolicies:
                 default:

--- a/package/crds/repository.upbound.io_repositories.yaml
+++ b/package/crds/repository.upbound.io_repositories.yaml
@@ -84,9 +84,11 @@ spec:
                     minLength: 1
                     type: string
                   public:
+                    default: false
                     description: Public determines the visibility of the repository
                     type: boolean
                   publish:
+                    default: false
                     description: Publish enables Upbound Marketplace listing page
                       for the new repository
                     type: boolean


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- Fixes # https://github.com/upbound/provider-upbound/issues/24

- bumped golangci-lint timeout to 3m
```yaml
run golangci-lint
  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=warning msg="[config_reader] The output format `github-actions` is deprecated, please use `colored-line-number`"
  level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."
  level=error msg="Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: context deadline exceeded"
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
``` 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I tested the code locally with and without my changes and was able to create a repo with just the name and organization: 
```yaml 
---
apiVersion: repository.upbound.io/v1alpha1
kind: Repository
metadata:
  name: default-test
spec:
  forProvider:
    name: default-test
    organizationName: upbound-platform
```
However, I was able to recreate the issue with the tag that contained the changes v0.8.0. I deployed a test tag (xpkg.upbound.io/upbound-platform/provider-upbound:v0.11.0-rc.0.6.gacfbf8e) containing these changes and confirmed that I can create a repository without explicitly setting the public` and `publish` values. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
