### PR TITLE
fix(panic): fix panic because of the logger

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -70,12 +70,7 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-upbound"))
-	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
-		ctrl.SetLogger(zl)
-	}
+	ctrl.SetLogger(zl)
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

currently log.SetLogger is only called if the flag "debug" is set to true. Due to https://github.com/kubernetes-sigs/controller-runtime/issues/2622
no default logger is set anymore, leading to this error:

```
kubectl logs -n crossplane-system  upbound-provider-upbound-fcce706222bb-b8dd9c9c4-8bfvb  
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	> goroutine 245 [running]:
	> runtime/debug.Stack()
	> 	runtime/debug/stack.go:26 +0x5e
	> sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/log/log.go:60 +0xcd
	> sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc000fbc040, 0x8)
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/log/deleg.go:111 +0x32
	> github.com/go-logr/logr.Logger.Enabled(...)
	> 	github.com/go-logr/logr@v1.4.2/logr.go:263
	> k8s.io/client-go/rest.logBody({0x20035a0?, 0xc0002121c0?}, 0x2, {0x1d16b67, 0xc}, {0xc00081d000, 0xe16, 0x1000})
	> 	k8s.io/client-go@v0.32.3/rest/request.go:1426 +0x90
	> k8s.io/client-go/rest.(*Request).Do(0xc000efac00, {0x20035a0, 0xc0002121c0})
	> 	k8s.io/client-go@v0.32.3/rest/request.go:1271 +0x95
	> sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).UpdateSubResource(0xc000436bd0, {0x20035a0, 0xc0002121c0}, {0x201eff0, 0xc000ea1800}, {0x1d0e543, 0x6}, {0x0, 0x0, 0x0})
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/client/typed_client.go:246 +0x470
	> sigs.k8s.io/controller-runtime/pkg/client.(*subResourceClient).Update(0xc00082c360, {0x20035a0, 0xc0002121c0}, {0x201eff0, 0xc000ea1800}, {0x0, 0x0, 0x0})
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/client/client.go:573 +0x28c
	> github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0xc00028a5a0, {0x20034f8, 0xc0010fdcb0}, {{{0x0, 0x0}, {0xc000878ee0, 0xe}}})
	> 	github.com/crossplane/crossplane-runtime@v1.18.0/pkg/reconciler/managed/reconciler.go:1016 +0xa7bf
	> sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc000fbc040?, {0x20034f8?, 0xc0010fdcb0?}, {{{0x0?, 0x0?}, {0xc000878ee0?, 0x0?}}})
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:118 +0xbf
	> sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x20185e0, {0x2003530, 0xc00002edc0}, {{{0x0, 0x0}, {0xc000878ee0, 0xe}}})
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:328 +0x3a5
	> sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x20185e0, {0x2003530, 0xc00002edc0})
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:288 +0x20e
	> sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:249 +0x85
	> created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 59
	> 	sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:245 +0x6b8
```

This Pull request fixes this error by always calling log.SetLogger

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
