### PR TITLE
Fix login API endpoint so that it makes use of the API endpoint configured in ProviderConfig

### DIFF
--- a/internal/client/upbound.go
+++ b/internal/client/upbound.go
@@ -49,6 +49,7 @@ const (
 	CookieName = "SID"
 
 	errNoIDInToken         = "no user id in personal access token"
+	errInvalidAPIEndpoint  = "unable to parse the API endpoint"
 	errLoginFailed         = "unable to login"
 	loginPath              = "/v1/login"
 	errReadBody            = "unable to read response body"
@@ -142,7 +143,11 @@ func createOrUpdateProfile(ctx context.Context, data []byte, pc *v1alpha1.Provid
 		return nil, errors.Wrap(err, errLoginFailed)
 	}
 
-	loginURL := createLoginURL(DefaultAPIEndpoint)
+	ep, err := getAPIEndpoint(pc)
+	if err != nil {
+		return nil, errors.Wrap(err, errInvalidAPIEndpoint)
+	}
+	loginURL := createLoginURL(ep)
 	req, err := createLoginRequest(ctx, loginURL, jsonStr)
 	if err != nil {
 		return nil, errors.Wrap(err, errLoginFailed)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Currently, the provider does not make use of the configured API endpoint in the referenced `ProviderConfig` when making a login request. This PR fixed that.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
